### PR TITLE
test: propagate sljit_test failure to the system

### DIFF
--- a/test_src/sljitMain.c
+++ b/test_src/sljitMain.c
@@ -29,7 +29,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 
-void sljit_test(int argc, char* argv[]);
+int sljit_test(int argc, char* argv[]);
 
 void error(const char* str)
 {
@@ -80,7 +80,5 @@ void devel(void)
 int main(int argc, char* argv[])
 {
 	/* devel(); */
-	sljit_test(argc, argv);
-
-	return 0;
+	return sljit_test(argc, argv);
 }

--- a/test_src/sljitTest.c
+++ b/test_src/sljitTest.c
@@ -6569,7 +6569,7 @@ static void test68(void)
 	successful_tests++;
 }
 
-void sljit_test(int argc, char* argv[])
+int sljit_test(int argc, char* argv[])
 {
 	sljit_s32 has_arg = (argc >= 2 && argv[1][0] == '-' && argv[1][2] == '\0');
 	verbose = has_arg && argv[1][1] == 'v';
@@ -6660,8 +6660,10 @@ void sljit_test(int argc, char* argv[])
 	if (successful_tests == TEST_COUNT)
 		printf("all tests are " COLOR_GREEN "PASSED" COLOR_DEFAULT " ");
 	else
-		printf(COLOR_RED "%d" COLOR_DEFAULT " (" COLOR_RED "%d%%" COLOR_DEFAULT ") tests are " COLOR_RED "FAILED" COLOR_DEFAULT " ", TEST_COUNT - successful_tests, (TEST_COUNT - successful_tests) * 100 / 47);
+		printf(COLOR_RED "%d" COLOR_DEFAULT " (" COLOR_RED "%d%%" COLOR_DEFAULT ") tests are " COLOR_RED "FAILED" COLOR_DEFAULT " ", TEST_COUNT - successful_tests, (TEST_COUNT - successful_tests) * 100 / TEST_COUNT);
 	printf("on " COLOR_ARCH "%s" COLOR_DEFAULT "%s\n", sljit_get_platform_name(), sljit_has_cpu_feature(SLJIT_HAS_FPU) ? " (with fpu)" : " (without fpu)");
+
+	return TEST_COUNT - successful_tests;
 
 #	undef TEST_COUNT
 }


### PR DESCRIPTION
Allow scripted checking of a test failure, by indicating an
error with a non zero return.

while at it, correct the returned percentage.